### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "type": "app",
   "categories": ["videos", "labeling"],
   "description": "Label videos for Action Recognition task",
-  "docker_image": "supervisely/labeling:6.72.182",
+  "docker_image": "supervisely/labeling:6.73.564",
   "main_script": "src/main.py",
   "gui_template": "src/gui.html",
   "task_location": "workspace_tasks",

--- a/config.json
+++ b/config.json
@@ -11,6 +11,6 @@
   "icon": "https://imgur.com/BJVjHij.png",
   "icon_cover": false,
   "icon_background": "#FFFFFF",
-  "min_instance_version": "6.8.48",
+  "instance_version": "6.15.60",
   "poster": "https://imgur.com/qgytUat.png"
 }

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "labeling"
   ],
   "description": "Label videos for Action Recognition task",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "main_script": "src/main.py",
   "gui_template": "src/gui.html",
   "task_location": "workspace_tasks",

--- a/config.json
+++ b/config.json
@@ -1,9 +1,12 @@
 {
   "name": "Action Recognition Labeling Tool",
   "type": "app",
-  "categories": ["videos", "labeling"],
+  "categories": [
+    "videos",
+    "labeling"
+  ],
   "description": "Label videos for Action Recognition task",
-  "docker_image": "supervisely/labeling:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "main_script": "src/main.py",
   "gui_template": "src/gui.html",
   "task_location": "workspace_tasks",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.72.182
+supervisely==6.73.564

--- a/src/sly_functions.py
+++ b/src/sly_functions.py
@@ -1,7 +1,7 @@
 import datetime
 from string import Formatter
 
-import supervisely_lib as sly
+import supervisely as sly
 from itertools import chain
 
 import sly_globals as g

--- a/src/sly_globals.py
+++ b/src/sly_globals.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import sys
 import pickle
 
-import supervisely_lib as sly
+import supervisely as sly
 from sly_fields_names import ItemsStatusField
 
 import sly_functions as f

--- a/src/ui/connect_to_controller.py
+++ b/src/ui/connect_to_controller.py
@@ -1,5 +1,5 @@
 import sly_globals as g
-import supervisely_lib as sly
+import supervisely as sly
 
 import sly_functions as f
 

--- a/src/ui/ui.py
+++ b/src/ui/ui.py
@@ -1,4 +1,4 @@
-import supervisely_lib as sly
+import supervisely as sly
 import sly_globals as g
 
 import connect_to_controller


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
